### PR TITLE
Allow tagging subnets (all/public/private) via var.subnet_tags*

### DIFF
--- a/aws/container-linux/kubernetes/network.tf
+++ b/aws/container-linux/kubernetes/network.tf
@@ -47,7 +47,6 @@ resource "aws_subnet" "public" {
   assign_ipv6_address_on_creation = true
 
   tags = "${merge(
-    var.subnet_tags,
     var.subnet_tags_public,
     map("Name", "${var.cluster_name}-public-${count.index}")
   )}"
@@ -71,7 +70,6 @@ resource "aws_subnet" "private" {
   assign_ipv6_address_on_creation = true
 
   tags = "${merge(
-    var.subnet_tags,
     var.subnet_tags_private,
     map("Name", "${var.cluster_name}-private-${count.index}")
   )}"

--- a/aws/container-linux/kubernetes/network.tf
+++ b/aws/container-linux/kubernetes/network.tf
@@ -46,7 +46,11 @@ resource "aws_subnet" "public" {
   map_public_ip_on_launch         = true
   assign_ipv6_address_on_creation = true
 
-  tags = "${map("Name", "${var.cluster_name}-public-${count.index}")}"
+  tags = "${merge(
+    var.subnet_tags,
+    var.subnet_tags_public,
+    map("Name", "${var.cluster_name}-public-${count.index}")
+  )}"
 }
 
 resource "aws_route_table_association" "public" {
@@ -66,7 +70,11 @@ resource "aws_subnet" "private" {
   ipv6_cidr_block                 = "${cidrsubnet(aws_vpc.network.ipv6_cidr_block, 8, count.index + 8)}"
   assign_ipv6_address_on_creation = true
 
-  tags = "${map("Name", "${var.cluster_name}-private-${count.index}")}"
+  tags = "${merge(
+    var.subnet_tags,
+    var.subnet_tags_private,
+    map("Name", "${var.cluster_name}-private-${count.index}")
+  )}"
 }
 
 resource "aws_route_table" "private" {

--- a/aws/container-linux/kubernetes/variables.tf
+++ b/aws/container-linux/kubernetes/variables.tf
@@ -186,12 +186,6 @@ variable "ca_key" {
   default     = ""
 }
 
-variable "subnet_tags" {
-  type = "map"
-  description = "Tags to apply to all subnets"
-  default = {}
-}
-
 variable "subnet_tags_private" {
   type = "map"
   description = "Tags to apply to private subnets"

--- a/aws/container-linux/kubernetes/variables.tf
+++ b/aws/container-linux/kubernetes/variables.tf
@@ -185,3 +185,21 @@ variable "ca_key" {
   type        = "string"
   default     = ""
 }
+
+variable "subnet_tags" {
+  type = "map"
+  description = "Tags to apply to all subnets"
+  default = {}
+}
+
+variable "subnet_tags_private" {
+  type = "map"
+  description = "Tags to apply to private subnets"
+  default = {}
+}
+
+variable "subnet_tags_public" {
+  type = "map"
+  description = "Tags to apply to public subnets"
+  default = {}
+}


### PR DESCRIPTION
This adds two variables: `subnet_tags_public`, and `subnet_tags_private`. Each is a map with a `{}` default. If unset, current behavior is unchanged. If set to a map, the entries are merged into the final tags map. 

This is required to support alb-ingress-controller which performs [tag-based discovery](https://github.com/kubernetes-sigs/aws-alb-ingress-controller/blob/master/docs/setup.md#via-tags-on-the-subnets) to choose the subnets into which an ALB will be launched based on cluster/scheme. 