### PR TITLE
Allow worker to assume any role

### DIFF
--- a/aws/container-linux/kubernetes/workers/workers.tf
+++ b/aws/container-linux/kubernetes/workers/workers.tf
@@ -88,6 +88,13 @@ resource "aws_iam_role_policy" "instance_read_ec2" {
   policy = "${data.aws_iam_policy_document.read_ec2.json}"
 }
 
+resource "aws_iam_role_policy" "instance_assume_role" {
+  name   = "instance-assume-role"
+  role   = "${aws_iam_role.worker.id}"
+  policy = "${data.aws_iam_policy_document.assume_role.json}"
+}
+
+
 data "aws_iam_policy_document" "read_ec2" {
   statement {
     actions   = ["ec2:Describe*"]
@@ -96,6 +103,13 @@ data "aws_iam_policy_document" "read_ec2" {
 }
 
 data "aws_iam_policy_document" "assume_role" {
+  statement {
+    actions   = ["sts:AssumeRole"]
+    resources = ["*"]
+  }
+}
+
+data "aws_iam_policy_document" "assume_role_from_ec2" {
   statement {
     actions = ["sts:AssumeRole"]
 
@@ -108,7 +122,7 @@ data "aws_iam_policy_document" "assume_role" {
 
 resource "aws_iam_role" "worker" {
   name               = "${var.name}-worker"
-  assume_role_policy = "${data.aws_iam_policy_document.assume_role.json}"
+  assume_role_policy = "${data.aws_iam_policy_document.assume_role_from_ec2.json}"
 }
 
 resource "aws_iam_instance_profile" "worker" {


### PR DESCRIPTION
App pods in a worker need to be able to assume different roles for obtaining access to different AWS resources, which can be in the same AWS account as the worker, or in a different AWS account.

The tool we use to achieve this is [kube2iam](https://github.com/jtblin/kube2iam), which requires worker role to have permission to assume any role.
See the detailed requirement https://github.com/jtblin/kube2iam#iam-roles