### PR TITLE
Output CA cert data for Kubernetes apiserver

### DIFF
--- a/aws/container-linux/kubernetes/outputs.tf
+++ b/aws/container-linux/kubernetes/outputs.tf
@@ -35,6 +35,11 @@ output "kubeconfig" {
   value = "${module.bootkube.kubeconfig-kubelet}"
 }
 
+output "kube_ca" {
+  description = "Base64-encoded CA cert data for Kubernetes apiserver"
+  value       = "${module.bootkube.ca_cert}"
+}
+
 # Outputs for custom load balancing
 
 output "worker_target_group_http" {


### PR DESCRIPTION
Exporting CA cert data for Kubernetes apiserver so that it can be [uploaded to S3 as an artifact](https://github.com/TakeScoop/kubernetes/blob/ae73fc52843864ec4e11b972da0e6071c1b9ded5/environments/staging/main.tf#L55).