### PR TITLE
Add workers autoscale group name as output

### DIFF
--- a/aws/container-linux/kubernetes/outputs.tf
+++ b/aws/container-linux/kubernetes/outputs.tf
@@ -98,7 +98,7 @@ output "worker_role" {
   description = "Instance role ARN attached to worker instances via instance profile"
 }
 
-output "worker_autoscale_group_name" {
+output "worker_autoscaling_group" {
   value       = "${module.workers.autoscale_group_name}"
-  description = "Name of the workers autoscale group"
+  description = "Name of the workers autoscaling group"
 }

--- a/aws/container-linux/kubernetes/outputs.tf
+++ b/aws/container-linux/kubernetes/outputs.tf
@@ -99,6 +99,6 @@ output "worker_role" {
 }
 
 output "worker_autoscaling_group" {
-  value       = "${module.workers.autoscale_group_name}"
+  value       = "${module.workers.autoscaling_group}"
   description = "Name of the workers autoscaling group"
 }

--- a/aws/container-linux/kubernetes/outputs.tf
+++ b/aws/container-linux/kubernetes/outputs.tf
@@ -97,3 +97,8 @@ output "worker_role" {
   value       = "${module.workers.instance_role}"
   description = "Instance role ARN attached to worker instances via instance profile"
 }
+
+output "worker_autoscale_groug_name" {
+  value       = "${module.workers.autoscale_group_name}"
+  description = "Name of the workers autoscale group"
+}

--- a/aws/container-linux/kubernetes/outputs.tf
+++ b/aws/container-linux/kubernetes/outputs.tf
@@ -98,7 +98,7 @@ output "worker_role" {
   description = "Instance role ARN attached to worker instances via instance profile"
 }
 
-output "worker_autoscale_groug_name" {
+output "worker_autoscale_group_name" {
   value       = "${module.workers.autoscale_group_name}"
   description = "Name of the workers autoscale group"
 }

--- a/aws/container-linux/kubernetes/workers/outputs.tf
+++ b/aws/container-linux/kubernetes/workers/outputs.tf
@@ -13,7 +13,7 @@ output "instance_role" {
   description = "IAM role ARN attached to instances via instance profile"
 }
 
-output "autoscale_group_name" {
+output "autoscaling_group" {
   value       = "${aws_autoscaling_group.workers.name}"
-  description = "Name of the workers autoscale group"
+  description = "Name of the workers autoscaling group"
 }

--- a/aws/container-linux/kubernetes/workers/outputs.tf
+++ b/aws/container-linux/kubernetes/workers/outputs.tf
@@ -12,3 +12,8 @@ output "instance_role" {
   value       = "${aws_iam_role.worker.arn}"
   description = "IAM role ARN attached to instances via instance profile"
 }
+
+output "autoscale_group_name" {
+  value       = "${aws_autoscaling_group.workers.name}"
+  description = "Name of the workers autoscale group"
+}


### PR DESCRIPTION
* Add worker autoscale group name as output

This output will be used to setup an NLB for deploying tunnelbox into kubernetes. The NLB will be attached to this autoscaling group by this output name via the terraform [autoscaling_attachment](https://www.terraform.io/docs/providers/aws/r/autoscaling_attachment.html).

## Testing

Testing in playground.