### PR TITLE
comment out ASG attachment for http/https

### DIFF
--- a/aws/container-linux/kubernetes/workers/workers.tf
+++ b/aws/container-linux/kubernetes/workers/workers.tf
@@ -16,10 +16,11 @@ resource "aws_autoscaling_group" "workers" {
   launch_configuration = "${aws_launch_configuration.worker.name}"
 
   # target groups to which instances should be added
-  target_group_arns = [
-    "${aws_lb_target_group.workers-http.id}",
-    "${aws_lb_target_group.workers-https.id}",
-  ]
+  # removed due to conflict with aws_autoscaling_attachment, also unused
+  # target_group_arns = [
+  #   "${aws_lb_target_group.workers-http.id}",
+  #   "${aws_lb_target_group.workers-https.id}",
+  # ]
 
   lifecycle {
     # override the default destroy and replace update behavior


### PR DESCRIPTION
Remove unused autoscaling attachment targets, they conflict with the aws_autoscaling_attachment resource we create outside of typhoon