### PR TITLE
Limit the cidr_block for SSH

### DIFF
--- a/aws/container-linux/kubernetes/security.tf
+++ b/aws/container-linux/kubernetes/security.tf
@@ -14,11 +14,21 @@ resource "aws_security_group" "controller" {
 resource "aws_security_group_rule" "controller-ssh" {
   security_group_id = "${aws_security_group.controller.id}"
 
-  type        = "ingress"
-  protocol    = "tcp"
-  from_port   = 22
-  to_port     = 22
-  cidr_blocks = ["0.0.0.0/0"]
+  type                     = "ingress"
+  protocol                 = "tcp"
+  from_port                = 22
+  to_port                  = 22
+  source_security_group_id = "${aws_security_group.worker.id}"
+}
+
+resource "aws_security_group_rule" "controller-ssh-self" {
+  security_group_id = "${aws_security_group.controller.id}"
+
+  type      = "ingress"
+  protocol  = "tcp"
+  from_port = 22
+  to_port   = 22
+  self      = true
 }
 
 resource "aws_security_group_rule" "controller-etcd" {
@@ -199,11 +209,21 @@ resource "aws_security_group" "worker" {
 resource "aws_security_group_rule" "worker-ssh" {
   security_group_id = "${aws_security_group.worker.id}"
 
-  type        = "ingress"
-  protocol    = "tcp"
-  from_port   = 22
-  to_port     = 22
-  cidr_blocks = ["0.0.0.0/0"]
+  type                     = "ingress"
+  protocol                 = "tcp"
+  from_port                = 22
+  to_port                  = 22
+  source_security_group_id = "${aws_security_group.controller.id}"
+}
+
+resource "aws_security_group_rule" "worker-ssh-self" {
+  security_group_id = "${aws_security_group.worker.id}"
+
+  type      = "ingress"
+  protocol  = "tcp"
+  from_port = 22
+  to_port   = 22
+  self      = true
 }
 
 resource "aws_security_group_rule" "worker-http" {

--- a/aws/container-linux/kubernetes/security.tf
+++ b/aws/container-linux/kubernetes/security.tf
@@ -199,11 +199,11 @@ resource "aws_security_group" "worker" {
 resource "aws_security_group_rule" "worker-ssh-bastion" {
   security_group_id = "${aws_security_group.worker.id}"
 
-  type      = "ingress"
-  protocol  = "tcp"
-  from_port = 22
-  to_port   = 22
-  cidr_blocks = [aws_security_group.bastion_internal.egress]
+  type                     = "ingress"
+  protocol                 = "tcp"
+  from_port                = 22
+  to_port                  = 22
+  source_security_group_id = aws_security_group.bastion_internal.id
 }
 
 resource "aws_security_group_rule" "worker-ssh-self" {

--- a/aws/container-linux/kubernetes/security.tf
+++ b/aws/container-linux/kubernetes/security.tf
@@ -196,6 +196,16 @@ resource "aws_security_group" "worker" {
   tags = "${map("Name", "${var.cluster_name}-worker")}"
 }
 
+resource "aws_security_group_rule" "worker-ssh-bastion" {
+  security_group_id = "${aws_security_group.worker.id}"
+
+  type      = "ingress"
+  protocol  = "tcp"
+  from_port = 22
+  to_port   = 22
+  cidr_blocks = [aws_security_group.bastion_internal.egress]
+}
+
 resource "aws_security_group_rule" "worker-ssh-self" {
   security_group_id = "${aws_security_group.worker.id}"
 

--- a/aws/container-linux/kubernetes/security.tf
+++ b/aws/container-linux/kubernetes/security.tf
@@ -21,16 +21,6 @@ resource "aws_security_group_rule" "controller-ssh" {
   source_security_group_id = "${aws_security_group.worker.id}"
 }
 
-resource "aws_security_group_rule" "controller-ssh-self" {
-  security_group_id = "${aws_security_group.controller.id}"
-
-  type      = "ingress"
-  protocol  = "tcp"
-  from_port = 22
-  to_port   = 22
-  self      = true
-}
-
 resource "aws_security_group_rule" "controller-etcd" {
   security_group_id = "${aws_security_group.controller.id}"
 
@@ -204,16 +194,6 @@ resource "aws_security_group" "worker" {
   vpc_id = "${aws_vpc.network.id}"
 
   tags = "${map("Name", "${var.cluster_name}-worker")}"
-}
-
-resource "aws_security_group_rule" "worker-ssh" {
-  security_group_id = "${aws_security_group.worker.id}"
-
-  type                     = "ingress"
-  protocol                 = "tcp"
-  from_port                = 22
-  to_port                  = 22
-  source_security_group_id = "${aws_security_group.controller.id}"
 }
 
 resource "aws_security_group_rule" "worker-ssh-self" {


### PR DESCRIPTION
Limit the SSH source addresses allowed to connect to the worker and the controller cidr_blocks. Instead of allowing all access, limit the sources to:

* workers can SSH to controllers
* workers can SSH to workers
* the Bastion can SSH to workers

https://takescoop.atlassian.net/browse/SEC-7
