### PR TITLE
Use external interface on bastion

### DIFF
--- a/aws/container-linux/kubernetes/security.tf
+++ b/aws/container-linux/kubernetes/security.tf
@@ -203,7 +203,7 @@ resource "aws_security_group_rule" "worker-ssh-bastion" {
   protocol                 = "tcp"
   from_port                = 22
   to_port                  = 22
-  source_security_group_id = "${aws_security_group.bastion_internal.id}"
+  source_security_group_id = "${aws_security_group.bastion_external.id}"
 }
 
 resource "aws_security_group_rule" "worker-ssh-self" {


### PR DESCRIPTION
The bastion external interface is the one we want to use to SSH to the controllers/workers.

https://takescoop.atlassian.net/browse/SEC-7