### PR TITLE
Split public route table and route definitions

### DIFF
--- a/aws/container-linux/kubernetes/network.tf
+++ b/aws/container-linux/kubernetes/network.tf
@@ -24,17 +24,19 @@ resource "aws_internet_gateway" "gateway" {
 resource "aws_route_table" "public" {
   vpc_id = "${aws_vpc.network.id}"
 
-  route {
-    cidr_block = "0.0.0.0/0"
-    gateway_id = "${aws_internet_gateway.gateway.id}"
-  }
-
-  route {
-    ipv6_cidr_block = "::/0"
-    gateway_id      = "${aws_internet_gateway.gateway.id}"
-  }
-
   tags = "${map("Name", "${var.cluster_name}-public")}"
+}
+
+resource "aws_route" "internet_gateway" {
+  route_table_id         = "${aws_route_table.public.id}"
+  destination_cidr_block = "0.0.0.0/0"
+  gateway_id             = "${aws_internet_gateway.gateway.id}"
+}
+
+resource "aws_route" "ipv6_internet_gateway" {
+  route_table_id              = "${aws_route_table.public.id}"
+  destination_ipv6_cidr_block = "::/0"
+  gateway_id                  = "${aws_internet_gateway.gateway.id}"
 }
 
 # Subnets (one per availability zone)


### PR DESCRIPTION
We are now adding [routes outside of typhoon](https://github.com/TakeScoop/kubernetes/blob/master/environments/playground/main.tf#L141-L150) from our Kubernetes route tables an external network gateway. Terraform can't reliably mix inline route definitions with attached routes, so we can make them all attached routes and they will play nicely. 

from [tf docs](https://www.terraform.io/docs/providers/aws/r/route_table.html):
```
NOTE on Route Tables and Routes: Terraform currently provides both a standalone Route resource and a Route Table resource with routes defined in-line. At this time you cannot use a Route Table with in-line routes in conjunction with any Route resources. Doing so will cause a conflict of rule settings and will overwrite rules.
```