### PR TITLE
remove ability to set different amis per instance role

### DIFF
--- a/aws/container-linux/kubernetes/bastion.tf
+++ b/aws/container-linux/kubernetes/bastion.tf
@@ -35,7 +35,7 @@ resource "aws_autoscaling_group" "bastion" {
 }
 
 resource "aws_launch_configuration" "bastion" {
-  image_id      = lookup(var.amis, "bastion", data.aws_ami.coreos.image_id)
+  image_id      = coalesce(var.ami, data.aws_ami.coreos.image_id)
   instance_type = var.bastion_type
 
   user_data = data.ct_config.bastion_ign.rendered

--- a/aws/container-linux/kubernetes/controllers.tf
+++ b/aws/container-linux/kubernetes/controllers.tf
@@ -24,7 +24,7 @@ resource "aws_instance" "controllers" {
 
   instance_type = var.controller_type
 
-  ami                  = lookup(var.amis, "controller", local.ami_id)
+  ami                  = coalesce(var.ami, local.ami_id)
   user_data            = data.ct_config.controller-ignitions.*.rendered[count.index]
   iam_instance_profile = aws_iam_instance_profile.controller.id
 

--- a/aws/container-linux/kubernetes/variables.tf
+++ b/aws/container-linux/kubernetes/variables.tf
@@ -188,10 +188,10 @@ variable "bastion_count" {
   description = "Number of bastion hosts to run"
 }
 
-variable "amis" {
+variable "ami" {
   type        = map(string)
-  description = "Static AMIs to use for different cluster roles. When no value is set for a role, the latest stable CoreOS AMI is used"
-  default     = { "" = "" }
+  description = "Custom AMI to use to launch instances. When no value is set for a role, the latest stable CoreOS AMI is used."
+  default     = ""
 }
 
 variable "ssh_user" {

--- a/aws/container-linux/kubernetes/variables.tf
+++ b/aws/container-linux/kubernetes/variables.tf
@@ -189,7 +189,7 @@ variable "bastion_count" {
 }
 
 variable "ami" {
-  type        = map(string)
+  type        = string
   description = "Custom AMI to use to launch instances. When no value is set for a role, the latest stable CoreOS AMI is used."
   default     = ""
 }

--- a/aws/container-linux/kubernetes/workers.tf
+++ b/aws/container-linux/kubernetes/workers.tf
@@ -22,6 +22,6 @@ module "workers" {
   node_labels           = var.worker_node_labels
 
   # scoop
-  ami = lookup(var.amis, "worker", "")
+  ami = var.ami
 }
 


### PR DESCRIPTION
We don't use this capability so I'd like to remove it in favor of a simpler single string