### PR TITLE
ssh: set private key for connections

### DIFF
--- a/aws/container-linux/kubernetes/ssh.tf
+++ b/aws/container-linux/kubernetes/ssh.tf
@@ -21,11 +21,11 @@ resource "null_resource" "copy-controller-secrets" {
 
     host        = aws_instance.controllers.*.private_ip[count.index]
     user        = var.ssh_user
-    private_key = var.ssh_authorized_key
+    private_key = var.ssh_private_key
 
     bastion_host        = aws_lb.bastion.dns_name
     bastion_user        = var.ssh_user
-    bastion_private_key = var.ssh_authorized_key
+    bastion_private_key = var.ssh_private_key
 
     timeout = "15m"
   }
@@ -55,11 +55,11 @@ resource "null_resource" "bootstrap" {
 
     host        = aws_instance.controllers[0].private_ip
     user        = var.ssh_user
-    private_key = var.ssh_authorized_key
+    private_key = var.ssh_private_key
 
     bastion_host        = aws_lb.bastion.dns_name
     bastion_user        = var.ssh_user
-    bastion_private_key = var.ssh_authorized_key
+    bastion_private_key = var.ssh_private_key
 
 
     timeout = "15m"

--- a/aws/container-linux/kubernetes/ssh.tf
+++ b/aws/container-linux/kubernetes/ssh.tf
@@ -19,11 +19,13 @@ resource "null_resource" "copy-controller-secrets" {
   connection {
     type = "ssh"
 
-    host = aws_instance.controllers.*.private_ip[count.index]
-    user = var.ssh_user
+    host        = aws_instance.controllers.*.private_ip[count.index]
+    user        = var.ssh_user
+    private_key = var.ssh_authorized_key
 
-    bastion_host = aws_lb.bastion.dns_name
-    bastion_user = var.ssh_user
+    bastion_host        = aws_lb.bastion.dns_name
+    bastion_user        = var.ssh_user
+    bastion_private_key = var.ssh_authorized_key
 
     timeout = "15m"
   }
@@ -51,11 +53,14 @@ resource "null_resource" "bootstrap" {
   connection {
     type = "ssh"
 
-    host = aws_instance.controllers[0].private_ip
-    user = var.ssh_user
+    host        = aws_instance.controllers[0].private_ip
+    user        = var.ssh_user
+    private_key = var.ssh_authorized_key
 
-    bastion_host = aws_lb.bastion.dns_name
-    bastion_user = var.ssh_user
+    bastion_host        = aws_lb.bastion.dns_name
+    bastion_user        = var.ssh_user
+    bastion_private_key = var.ssh_authorized_key
+
 
     timeout = "15m"
   }

--- a/aws/container-linux/kubernetes/variables.tf
+++ b/aws/container-linux/kubernetes/variables.tf
@@ -97,6 +97,11 @@ variable "bastion_clc_snippets" {
 
 # configuration
 
+variable "ssh_authorized_key" {
+  type        = string
+  description = "SSH public key for var.ssh_user"
+}
+
 variable "networking" {
   type        = string
   description = "Choice of networking provider (calico or flannel)"

--- a/aws/container-linux/kubernetes/variables.tf
+++ b/aws/container-linux/kubernetes/variables.tf
@@ -97,11 +97,6 @@ variable "bastion_clc_snippets" {
 
 # configuration
 
-variable "ssh_private_key" {
-  type        = string
-  description = "SSH private key to use with provisioners"
-}
-
 variable "networking" {
   type        = string
   description = "Choice of networking provider (calico or flannel)"
@@ -202,6 +197,11 @@ variable "ami" {
 variable "ssh_user" {
   type        = string
   description = "Username for provisioning via SSH"
+}
+
+variable "ssh_private_key" {
+  type        = string
+  description = "SSH private key to use with provisioners"
 }
 
 variable "subnet_tags_private" {

--- a/aws/container-linux/kubernetes/variables.tf
+++ b/aws/container-linux/kubernetes/variables.tf
@@ -97,9 +97,9 @@ variable "bastion_clc_snippets" {
 
 # configuration
 
-variable "ssh_authorized_key" {
+variable "ssh_private_key" {
   type        = string
-  description = "SSH public key for var.ssh_user"
+  description = "SSH private key to use with provisioners"
 }
 
 variable "networking" {


### PR DESCRIPTION
Specifies the private key directly in SSH connections. This allows the private key to be generated by Terraform.

This is a speculative change and so I'm opening it as a draft. I'm not sure how this change will interact with `ssh-agent`. If the private key is not added there, the provisioner will be unable to use `sudo` in our clusters. 

No clear indications either way in the underlying package that implements this:

https://github.com/hashicorp/terraform/tree/master/communicator/ssh

And no info in the TF Cloud docs on whether providing a workspace SSH key is implemented by adding the key to `ssh-agent`:

https://www.terraform.io/docs/cloud/workspaces/ssh-keys.html