### PR TITLE
Route table outputs

### DIFF
--- a/aws/container-linux/kubernetes/controllers.tf
+++ b/aws/container-linux/kubernetes/controllers.tf
@@ -49,7 +49,7 @@ EOF
   }
 
   # network
-  subnet_id = aws_subnet.private.*.id[count.index]
+  subnet_id = element(aws_subnet.private.*.id, count.index)
   vpc_security_group_ids = [
     aws_security_group.controller.id,
     aws_security_group.bastion_internal.id

--- a/aws/container-linux/kubernetes/outputs.tf
+++ b/aws/container-linux/kubernetes/outputs.tf
@@ -90,12 +90,12 @@ output "nat_ips" {
 
 output "private_route_tables" {
   value       = aws_route_table.private.*.id
-  description = "ID of the private route table that can be used to add additional private routes"
+  description = "IDs of the private route tables that can be used to add additional private routes"
 }
 
-output "private_route_tables_map" {
-  value       = aws_route_table.private 
-  description = "Map of private route table resource IDs to aws_route_table objects, suitable for use in for_each"
+output "private_route_tables_count" {
+  value       = length(aws_route_table.private)
+  description = "Number of private route tables that are created"
 }
 
 output "public_route_tables" {
@@ -103,9 +103,9 @@ output "public_route_tables" {
   description = "IDs of the public route tables"
 }
 
-output "public_route_tables_map" {
-  value       = aws_route_table.public 
-  description = "Map of public route table resource IDs to aws_route_table objects, suitable for use in for_each"
+output "public_route_tables_count" {
+  value       = length(aws_route_table.public)
+  description = "Number of public route tables that are created"
 }
 
 output "depends_id" {


### PR DESCRIPTION
Follows #43. Having `_map` outputs would make sense if typhoon were using `for_each`, which it's not. Wishful thinking there/force of habit.

Instead, this PR outputs a `_count` that is derived at plan time, whereas `aws_route_table.private.*.id` is not known until apply time.

Not truly related but sneaking in in this PR is also a fix for when you have more controllers than subnets (https://github.com/poseidon/typhoon/pull/714). 