### PR TITLE
Enable pretty_print otherwise ct renders empty Ignition

### DIFF
--- a/aws/fedora-coreos/kubernetes/bastion.tf
+++ b/aws/fedora-coreos/kubernetes/bastion.tf
@@ -82,6 +82,10 @@ data "ct_config" "bastion_ign" {
   content  = file("${path.module}/fcc/bastion.yaml")
   strict   = true
   snippets = var.bastion_snippets
+
+  # As for ct@v0.7.0, if pretty_print is set to false, non-empty snippets will empty the rendered Ignition.
+  # This is likely a bug of ct provider.
+  pretty_print = true
 }
 
 resource "aws_security_group" "bastion_external" {

--- a/aws/fedora-coreos/kubernetes/controllers.tf
+++ b/aws/fedora-coreos/kubernetes/controllers.tf
@@ -81,6 +81,10 @@ data "ct_config" "controller-ignitions" {
   content  = data.template_file.controller-configs.*.rendered[count.index]
   strict   = true
   snippets = var.controller_snippets
+
+  # As for ct@v0.7.0, if pretty_print is set to false, non-empty snippets will empty the rendered Ignition.
+  # This is likely a bug of ct provider.
+  pretty_print = true
 }
 
 # Controller Fedora CoreOS configs

--- a/aws/fedora-coreos/kubernetes/workers/workers.tf
+++ b/aws/fedora-coreos/kubernetes/workers/workers.tf
@@ -107,6 +107,10 @@ data "ct_config" "worker-ignition" {
   content  = data.template_file.worker-config.rendered
   strict   = true
   snippets = var.snippets
+
+  # As for ct@v0.7.0, if pretty_print is set to false, non-empty snippets will empty the rendered Ignition.
+  # This is likely a bug of ct provider.
+  pretty_print = true
 }
 
 # Worker Fedora CoreOS config


### PR DESCRIPTION
As for ct@v0.7.0, if pretty_print is set to false, non-empty snippets will empty the rendered Ignition.
This is likely a bug of ct provider.