### PR TITLE
enable SMT on Fedora CoreOS Kubernetes nodes

### DIFF
--- a/aws/fedora-coreos/kubernetes/fcc/controller.yaml
+++ b/aws/fedora-coreos/kubernetes/fcc/controller.yaml
@@ -3,6 +3,26 @@ variant: fcos
 version: 1.1.0
 systemd:
   units:
+    - name: enable-smt.service
+      enabled: true
+      contents: |
+        # https://docs.fedoraproject.org/be/fedora-coreos/kernel-args/
+        [Unit]
+        Description=Enable simultaneous multithreading
+        Before=kubelet.service
+        # We run after `systemd-machine-id-commit.service` to ensure that
+        # `ConditionFirstBoot=true` services won't rerun on the next boot.
+        After=systemd-machine-id-commit.service
+        ConditionKernelCommandLine=mitigations
+        
+        [Service]
+        Type=oneshot
+        RemainAfterExit=yes
+        ExecStart=/bin/rpm-ostree kargs --delete mitigations --reboot
+
+        [Install]
+        RequiredBy=kubelet.service
+        WantedBy=multi-user.target
     - name: etcd-member.service
       enabled: true
       contents: |

--- a/aws/fedora-coreos/kubernetes/workers/fcc/worker.yaml
+++ b/aws/fedora-coreos/kubernetes/workers/fcc/worker.yaml
@@ -3,6 +3,27 @@ variant: fcos
 version: 1.1.0
 systemd:
   units:
+    - name: enable-smt.service
+      enabled: true
+      contents: |
+        # https://docs.fedoraproject.org/be/fedora-coreos/kernel-args/
+        [Unit]
+        Description=Enable simultaneous multithreading
+        Before=kubelet.service
+        # We run after `systemd-machine-id-commit.service` to ensure that
+        # `ConditionFirstBoot=true` services won't rerun on the next boot.
+        After=systemd-machine-id-commit.service
+        ConditionKernelCommandLine=mitigations
+        
+        [Service]
+        Type=oneshot
+        RemainAfterExit=yes
+        ExecStart=/bin/rpm-ostree kargs --delete mitigations --reboot
+
+        [Install]
+        RequiredBy=kubelet.service
+        WantedBy=multi-user.target
+    - name: etcd-member.service
     - name: docker.service
       enabled: true
     - name: wait-for-dns.service

--- a/aws/fedora-coreos/kubernetes/workers/fcc/worker.yaml
+++ b/aws/fedora-coreos/kubernetes/workers/fcc/worker.yaml
@@ -23,7 +23,6 @@ systemd:
         [Install]
         RequiredBy=kubelet.service
         WantedBy=multi-user.target
-    - name: etcd-member.service
     - name: docker.service
       enabled: true
     - name: wait-for-dns.service


### PR DESCRIPTION
In Fedora CoreOS, this enables simultaneous multi-threading to ensure that Kubernetes sees the correct number of virtual CPU cores. AWS implements protections against the sorts of attacks disabling SMT is meant to prevent, and disabling SMT will likely reduce performance. We need capacity to be correctly reported, otherwise a well utilized cluster will significantly exceed capacity and be unschedulable.

https://aws.amazon.com/security/security-bulletins/AWS-2019-004/

It implements a systemd unit that updates the kernel arguments to remove the default "mitigations" flag and and reboots. This proves to not disrupt the initialization process. Running it before the kubelet service provides some extra assurance but may not be necessary. I've tested this and it doesn't end up disrupting the Terraform run or any other part of initialization/bootstrapping.

See:

https://github.com/coreos/fedora-coreos-tracker/issues/413
https://github.com/coreos/fedora-coreos-tracker/issues/181
https://github.com/coreos/fedora-coreos-tracker/issues/318
https://github.com/poseidon/typhoon/issues/902